### PR TITLE
Add UMD loader for use with RequireJS

### DIFF
--- a/jquery-scrollLock.js
+++ b/jquery-scrollLock.js
@@ -5,7 +5,15 @@
  * Copyright (c) 2014 Mohammad Younes
  * Licensed under the MIT license.
  */
-(function ($) {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
 
   var eventName = "onmousewheel" in window ? (("ActiveXObject" in window) ? "wheel" : "mousewheel") : "DOMMouseScroll";
   var eventNamespace = ".scrollLock";
@@ -57,4 +65,4 @@
     $.fn.scrollLock = old
     return this;
   }
-})(jQuery);
+}));


### PR DESCRIPTION
Change the loader to use the UMD jquery plugin pattern so that this
plugin can easily be used with RequireJS and other AMD systems, as well
as with traditional <script> tag loading or script concatenation.
