### PR TITLE
Add bower.json to enable adding bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/*

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "jquery.scrollLock",
+  "version": "0.1.6",
+  "main": "jquery-scrollLock.js",
+  "license": "MIT",
+  "ignore": [
+    ".gitignore",
+    "jquery-scrollLock.min.js",
+    "scrollLock.jquery.json"
+  ],
+  "dependencies": {
+    "jquery": ">=1.7"
+  }
+}


### PR DESCRIPTION
These changes set you up to enable explicit Bower (http://bower.io/)
support by registering as a package
(http://bower.io/#registering-packages), and allows people to already
reference the github repo to install it directly. Given that Bower's
preferred method of version detection is through Git tags, it'd be
great to bump the version and tag it if you decide to include these
changes, otherwise Bower will get really confused.
