### PR TITLE
Fix unblock to work for touchstart and touchmove.

### DIFF
--- a/jquery-scrollLock.js
+++ b/jquery-scrollLock.js
@@ -55,6 +55,11 @@
     if (this.options.touch) {
       this.$element.on('touchstart' + ScrollLock.NAMESPACE, this.options.selector, $.proxy(ScrollLock.CORE.touchHandler, this))
       this.$element.on('touchmove' + ScrollLock.NAMESPACE, this.options.selector, $.proxy(ScrollLock.CORE.handler, this))
+      
+      if (this.options.unblock) {
+        this.$element.on('touchstart' + ScrollLock.NAMESPACE, this.options.unblock, $.proxy(ScrollLock.CORE.unblockHandler, this))
+        this.$element.on('touchmove' + ScrollLock.NAMESPACE, this.options.unblock, $.proxy(ScrollLock.CORE.unblockHandler, this))
+      }
     }
     if (this.options.keyboard) {
       this.$element.attr('tabindex', this.options.keyboard.tabindex || 0)

--- a/jquery-scrollLock.js
+++ b/jquery-scrollLock.js
@@ -57,7 +57,6 @@
       this.$element.on('touchmove' + ScrollLock.NAMESPACE, this.options.selector, $.proxy(ScrollLock.CORE.handler, this))
       
       if (this.options.unblock) {
-        this.$element.on('touchstart' + ScrollLock.NAMESPACE, this.options.unblock, $.proxy(ScrollLock.CORE.unblockHandler, this))
         this.$element.on('touchmove' + ScrollLock.NAMESPACE, this.options.unblock, $.proxy(ScrollLock.CORE.unblockHandler, this))
       }
     }


### PR DESCRIPTION
This fixes an issue where using `unblock` was not working for touch events.

In my project, I'm using scrollLock on a container that has a nested scrollable container. I passed in the `unblock` option, but it wasn't working on mobile. This change fixes this issue.